### PR TITLE
check if reply result is already decoded

### DIFF
--- a/share_handler_platform_interface/lib/src/data/messages.dart
+++ b/share_handler_platform_interface/lib/src/data/messages.dart
@@ -151,6 +151,10 @@ class ShareHandlerApi {
         details: error['details'],
       );
     } else if (replyMap['result'] != null) {
+      if (replyMap['result'] is SharedMedia) {
+        return replyMap['result'] as SharedMedia;
+      }
+
       return SharedMedia.decode(replyMap['result']!);
     } else {
       return null;


### PR DESCRIPTION
This fixes some conflicts when using with other packages. I have not been able to debug this to find the root cause but in my project there was an error that the SharedMedia was being decoded twice when getting initial media. The same problem was mentioned here: https://github.com/AboutShout/share_handler/issues/3 This checks the incomming result and if it is already SharedMedia type it returns instead of decoding.

